### PR TITLE
Fix parameters pass to emperavi js

### DIFF
--- a/Widget.php
+++ b/Widget.php
@@ -108,13 +108,13 @@ class Widget extends \yii\base\Widget
          */
         $appLanguage = strtolower(substr(Yii::$app->language , 0, 2)); //First 2 letters
         if($appLanguage != 'en') // By default $language = 'en-US', someone use underscore
-            $this->htmlOptions['lang'] = $appLanguage;
+            $this->options['lang'] = $appLanguage;
 
         // Insert plugins in options
         if (!empty($this->plugins)) {
-            $this->htmlOptions['plugins'] = $this->plugins;
+            $this->options['plugins'] = $this->plugins;
 
-            foreach($this->htmlOptions['plugins'] as $plugin) {
+            foreach($this->options['plugins'] as $plugin) {
                 $this->registerPlugin($plugin);
             }
         }


### PR DESCRIPTION
Splitted options for JS and HTML textarea. Otherwise it impossible to pass some params to js.
For example below code will crash an app

``` php
<?= $form->field($model, 'body')->widget(yii\imperavi\Widget::className(),[
    'options'=> [
        'uploadFields' => [
            'xxx' => 'yyy'
        ]
     ]
...
```
