### PR TITLE
Fix the critical bug!

### DIFF
--- a/assets/redactor.js
+++ b/assets/redactor.js
@@ -2383,7 +2383,7 @@
 					html = html.replace(new RegExp('<img(.*?[^>])>', 'gi'), '<img$1 data-verified="redactor">');
 					html = html.replace(new RegExp('<span(.*?)>', 'gi'), '<span$1 data-verified="redactor">');
 
-					var matches = html.match(new RegExp('<(span|img)(.*?)style="(.*?)"(.*?[^>])>', 'gi'));
+					var matches = html.match(new RegExp('<(span|img)([^>]*)style="(.*?)"(.*?[^>])>', 'gi'));
 					if (matches)
 					{
 						var len = matches.length;


### PR DESCRIPTION
Today I've got error on site (in production!) which work very well more then 6 month.
The editor is fail after inserting a text and my client have not any chance to fix it.
So, what I've found.
In editor was text (html) like this:
```html
<span attributes..>text text<img style="width:100%"/>text text</span>
```
And error that was showed in browser console ("..." is replaced text here):
```
 Uncaught SyntaxError: Invalid regular expression: /<span class="st" data-verified="redactor">..... <span class="st" data-verified="redactor"><em></em>......</span></p><p><span class="st" data-verified="redactor">....</span></p><p><img style="width:100%;" src="/uploads/images/vvvvv.jpg" alt="vvvv.jpg" data-verified="redactor">/: Unmatched ')'   redactor.js:2213
```
And what I see in line 2213? An incorrect regexp!
Now it has:
```var matches = html.match(new RegExp('<(span|img)(.*?)style="(.*?)"(.*?[^>])>', 'gi'));```
But it's wrong! THIS WRONG ->  ```new RegExp('<(span|img)  -->> (.*?) <<--  style="(.*?)"(.*?[^>])>', 'gi')```  because it can matches with
```html
<span{there is no check of close > tag} style="..." ...><img style="..." ...>
```
So this regexp must be like this:
```javascript
var matches = html.match(new RegExp('<(span|img)([^>]*)style="(.*?)"(.*?[^>])>', 'gi'));
```